### PR TITLE
Generify HttpResponseMessage

### DIFF
--- a/src/main/java/com/microsoft/azure/functions/HttpRequestMessage.java
+++ b/src/main/java/com/microsoft/azure/functions/HttpRequestMessage.java
@@ -64,8 +64,9 @@ public interface HttpRequestMessage<T> {
      * @param status The HTTP status code to return to the caller of the function.
      * @return An {@link HttpResponseMessage.Builder} instance containing the provided status and
      *         empty body.
+     * @param <R> The type of the body object that will be sent as a part of the HTTP Response
      */
-    HttpResponseMessage.Builder createResponseBuilder(HttpStatus status);
+    <R> HttpResponseMessage.Builder<R> createResponseBuilder(HttpStatus status);
 
     /**
      * Returns a {@link HttpResponseMessage.Builder} instance to build a HttpResponseMessage with
@@ -74,7 +75,8 @@ public interface HttpRequestMessage<T> {
      * @param status The HTTP status code to return to the caller of the function.
      * @return An {@link HttpResponseMessage.Builder} instance containing the provided status and
      *         empty body.
+     * @param <R> The type of the body object that will be sent as a part of the HTTP Response
      */
-    HttpResponseMessage.Builder createResponseBuilder(HttpStatusType status);
+    <R> HttpResponseMessage.Builder<R> createResponseBuilder(HttpStatusType status);
 
 }

--- a/src/main/java/com/microsoft/azure/functions/HttpResponseMessage.java
+++ b/src/main/java/com/microsoft/azure/functions/HttpResponseMessage.java
@@ -13,8 +13,9 @@ package com.microsoft.azure.functions;
  * {https://github.com/Azure/azure-functions-java-library/blob/dev/src/main/java/com/microsoft/azure/functions/annotation/HttpTrigger.java}
  * @see HttpRequestMessage
  * @since 1.0.0
+ * @param <T> The type of the body object that will be sent as a part of the HTTP Response
  */
-public interface HttpResponseMessage {
+public interface HttpResponseMessage<T> {
 
     /**
      * Returns the HTTP status code set on the HttpResponseMessage instance.
@@ -45,12 +46,13 @@ public interface HttpResponseMessage {
      * 
      * @return the body of the HTTP response.
      */
-    Object getBody();
+    T getBody();
     
     /**
-     * A builder to create an instance of HttpResponseMessage 
+     * A builder to create an instance of HttpResponseMessage
+     * @param <T> the type of the body object that will be sent as a part of the HTTP Response
      */
-    public interface Builder {
+    interface Builder<T> {
 
         /**
          * Sets the status code to be used in the HttpResponseMessage object.
@@ -61,7 +63,7 @@ public interface HttpResponseMessage {
          * @param status An HTTP status code representing the outcome of the HTTP request.
          * @return this builder
          */
-        Builder status(HttpStatusType status);
+        Builder<T> status(HttpStatusType status);
 
         /**
          * Adds a (key, value) header to the response.
@@ -70,7 +72,7 @@ public interface HttpResponseMessage {
          * @param value The value of the header value.
          * @return this builder
          */
-        Builder header(String key, String value);
+        Builder<T> header(String key, String value);
 
         /**
          * Sets the body of the HTTP response.
@@ -78,13 +80,13 @@ public interface HttpResponseMessage {
          * @param body The body of the HTTP response
          * @return this builder
          */
-        Builder body(Object body);
+        Builder<T> body(T body);
 
         /**
          * Creates an instance of HttpMessageResponse with the values configured in this builder.
          * 
          * @return an HttpMessageResponse object
          */
-        HttpResponseMessage build();
+        HttpResponseMessage<T> build();
     }
 }

--- a/src/test/java/com/microsoft/azure/functions/HttpStatusTest.java
+++ b/src/test/java/com/microsoft/azure/functions/HttpStatusTest.java
@@ -9,19 +9,19 @@ import static junit.framework.TestCase.*;
  */
 public class HttpStatusTest {
     @Test
-    public void set_custom_httpstatuscode() {
+    public void test_settingCustomStatusCode() {
         HttpStatusType customHttpStatus = HttpStatusType.custom(209);
-        assertTrue(customHttpStatus.value() == 209);
+        assertEquals(209, customHttpStatus.value());
     }
 
     @Test
-    public void set_standard_httpstatuscode() {
+    public void test_standardStatusCode() {
         HttpStatusType customHttpStatus = HttpStatus.OK;
-        assertTrue(customHttpStatus.value() == 200);
+        assertEquals(200, customHttpStatus.value());
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void set_invalid_httpstatuscode() {
+    public void test_invalidStatusCode_throwsException() {
         HttpStatusType.custom(-100);
     }
 }


### PR DESCRIPTION
Having HttpResponseMessage supporting generics would benefit developers in many ways:

- The type-safety could be enforced
- Simpler mocking in tests
- Ability to reflect on functions' signatures, so to discern true object types in the responses
    - This could allow the generation of documentation with the proper data types in the responses - e.g. OpenAPI documentation could be generated by using reflection