### PR TITLE
Adjust name of Java Core Library in pom.xml

### DIFF
--- a/azure-functions-java-core-library/pom.xml
+++ b/azure-functions-java-core-library/pom.xml
@@ -13,7 +13,7 @@
         <relativePath></relativePath>
     </parent>
 
-    <name>Microsoft Azure Functions Java Core Types</name>
+    <name>Microsoft Azure Functions Java Core Library</name>
     <description>This package contains core Java classes to interact with Microsoft Azure functions runtime.</description>
     <url>https://azure.microsoft.com/en-us/services/functions</url>
 


### PR DESCRIPTION
Java Core Types is the name of another library, see https://github.com/Azure/azure-functions-java-library/blob/dev/pom.xml Having two libraries with the same name is confusing.

### Issue describing the changes in this PR

#22 Misleading maven Library name "Java Core Types"

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes are added to the `CHANGELOG.md`
  Does not apply.
* [ ] I have added all required tests (Unit tests, E2E tests)
  Does not apply.