### PR TITLE
fix: exclude paths from codeql evaluation, skip e2e tests on scheduled runs and update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,5 +6,5 @@
 #   https://blog.github.com/2017-07-06-introducing-code-owners/
 #   https://help.github.com/articles/about-codeowners/  
 
-# Default owner for repo
-*	@manvkaur @vrdmr @gavin-aguiar @hallvictoria @ahmedmuhsin
+# Default owners for repo
+*	@Azure/azure-functions-java-worker-admins

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,5 +7,4 @@
 #   https://help.github.com/articles/about-codeowners/  
 
 # Default owner for repo
-*	@pragnagopa
-*   @amamounelsayed
+*	@manvkaur @vrdmr @gavin-aguiar @hallvictoria @ahmedmuhsin

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,4 +7,4 @@
 #   https://help.github.com/articles/about-codeowners/  
 
 # Default owners for repo
-* @azure/azure-functions-extensions-bundle-admins
+* @azure/azure-functions-java-worker-admins

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,4 +7,4 @@
 #   https://help.github.com/articles/about-codeowners/  
 
 # Default owners for repo
-*	@Azure/azure-functions-java-worker-admins
+* @azure/azure-functions-extensions-bundle-admins

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -57,4 +57,4 @@ extends:
       jobs:
       - template: /eng/ci/templates/official/jobs/build-and-test.yml@self
         parameters:
-          runEndToEndTests: ${{ and(ne(variables['Build.Reason'], 'Schedule'), eq('${{ parameters.runEndToEndTests }}', true)) }}
+          runEndToEndTests: ${{ and(ne(variables['Build.Reason'], 'Schedule'), parameters.runEndToEndTests) }}

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -43,9 +43,6 @@ extends:
       name: 1es-pool-azfunc
       image: 1es-windows-2022
       os: windows
-    sdl:
-      codeql:
-        enabledOnNonDefaultBranches: true
 
     stages:
     - stage: BuildAndTest

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -35,7 +35,12 @@ resources:
 variables:
   - template: ci/variables/build.yml@eng
   - template: ci/variables/cfs.yml@eng
-
+  - name: codeql.language
+    value: java,powershell
+  - name: codeql.buildIdentifier
+    value: java_additions_official
+  - name: codeql.excludePathPatterns
+    value: '/extract,/azure-maven-archetypes,/azure-maven-plugins,/azure-functions-java-library,/azure-functions-java-worker'
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1es
@@ -47,12 +52,6 @@ extends:
 
     stages:
     - stage: BuildAndTest
-      templateContext:
-        sdl:
-          codeql:
-            runSourceLanguagesInSourceAnalysis: true
-            buildIdentifier: java_additions_official
-            excludePathPatterns: '/extract,/azure-maven-archetypes,/azure-maven-plugins,/azure-functions-java-library'
 
       jobs:
       - template: /eng/ci/templates/official/jobs/build-and-test.yml@self

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -12,6 +12,12 @@ trigger:
     include:
     - dev
 
+parameters:
+  - name: runEndToEndTests
+    type: boolean
+    default: true
+    displayName: "Run end-to-end tests"
+
 # CI only, does not trigger on PRs.
 pr: none
 
@@ -52,3 +58,5 @@ extends:
 
       jobs:
       - template: /eng/ci/templates/official/jobs/build-and-test.yml@self
+        parameters:
+          runEndToEndTests: ${{ parameters.runEndToEndTests }}

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -40,6 +40,12 @@ extends:
 
     stages:
     - stage: BuildAndTest
+      templateContext:
+        sdl:
+          codeql:
+            runSourceLanguagesInSourceAnalysis: true
+            buildIdentifier: java_additions_official
+            excludePathPatterns: '/extract,/azure-maven-archetypes,/azure-maven-plugins,/azure-functions-java-library'
 
       jobs:
       - template: /eng/ci/templates/official/jobs/build-and-test.yml@self

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -36,6 +36,7 @@ variables:
   - template: ci/variables/build.yml@eng
   - template: ci/variables/cfs.yml@eng
 
+
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1es
   parameters:
@@ -56,4 +57,4 @@ extends:
       jobs:
       - template: /eng/ci/templates/official/jobs/build-and-test.yml@self
         parameters:
-          runEndToEndTests: ${{ parameters.runEndToEndTests }}
+          runEndToEndTests: ${{ and(ne(variables['Build.Reason'], 'Schedule'), eq('${{ parameters.runEndToEndTests }}', true)) }}

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -37,6 +37,9 @@ extends:
       name: 1es-pool-azfunc
       image: 1es-windows-2022
       os: windows
+    sdl:
+      codeql:
+        enabledOnNonDefaultBranches: true
 
     stages:
     - stage: BuildAndTest

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -24,6 +24,14 @@ resources:
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
 
+variables:
+  - name: codeql.language
+    value: java,powershell
+  - name: codeql.buildIdentifier
+    value: java_additions_public
+  - name: codeql.excludePathPatterns
+    value: '/extract,/azure-maven-archetypes,/azure-maven-plugins,/azure-functions-java-library,/azure-functions-java-worker'
+
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
   parameters:
@@ -34,12 +42,6 @@ extends:
 
     stages:
     - stage: Build
-      templateContext:
-        sdl:
-          codeql:
-            runSourceLanguagesInSourceAnalysis: true
-            buildIdentifier: java_additions_public
-            excludePathPatterns: '/extract,/azure-maven-archetypes,/azure-maven-plugins,/azure-functions-java-library'
 
       jobs:
       - template: /eng/ci/templates/jobs/build.yml@self

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -32,16 +32,14 @@ extends:
       image: 1es-windows-2022
       os: windows
 
-    sdl:
-      codeql:
-         compiled:
-           enabled: true
-         runSourceLanguagesInSourceAnalysis: true
-         buildIdentifier: java_additions_public
-         excludePathPatterns: '/extract,/azure-maven-archetypes,/azure-maven-plugins,/azure-functions-java-library'
-
     stages:
     - stage: Build
+      templateContext:
+        sdl:
+          codeql:
+            runSourceLanguagesInSourceAnalysis: true
+            buildIdentifier: java_additions_public
+            excludePathPatterns: '/extract,/azure-maven-archetypes,/azure-maven-plugins,/azure-functions-java-library'
 
       jobs:
       - template: /eng/ci/templates/jobs/build.yml@self

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -37,6 +37,8 @@ extends:
          compiled:
            enabled: true
          runSourceLanguagesInSourceAnalysis: true
+         buildIdentifier: java_additions_public
+         excludePathPatterns: '/extract,/azure-maven-archetypes,/azure-maven-plugins,/azure-functions-java-library'
 
     stages:
     - stage: Build

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -40,6 +40,10 @@ extends:
       image: 1es-windows-2022
       os: windows
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
     stages:
     - stage: Build
 

--- a/eng/ci/templates/official/jobs/build-and-test.yml
+++ b/eng/ci/templates/official/jobs/build-and-test.yml
@@ -39,7 +39,7 @@ jobs:
         versionSpec: '8'
         jdkArchitectureOption: 'x64'
         jdkSourceOption: 'PreInstalled'
-      condition: eq('${{ parameters.runEndToEndTests }}', true)
+      condition: eq(${{ parameters.runEndToEndTests }}, true)
 
     - pwsh: |
         $currDir =  Get-Location
@@ -50,13 +50,13 @@ jobs:
         mvn clean package `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
         Copy-Item "confluent_cloud_cacert.pem" ".\target\azure-functions\azure-functions-java-endtoendtests"
       displayName: 'Package Java for E2E'
-      condition: eq('${{ parameters.runEndToEndTests }}', true)
+      condition: eq(${{ parameters.runEndToEndTests }}, true)
 
     - bash: |
         docker compose -f azure-functions-java-worker/emulatedtests/utils/docker-compose.yml pull
         docker compose -f azure-functions-java-worker/emulatedtests/utils/docker-compose.yml up -d
       displayName: 'Install Azurite and Start Emulators'
-      condition: eq('${{ parameters.runEndToEndTests }}', true)
+      condition: eq(${{ parameters.runEndToEndTests }}, true)
 
     - task: DotNetCoreCLI@2
       retryCountOnTaskFailure: 3
@@ -68,5 +68,5 @@ jobs:
         AzureWebJobsStorage: "UseDevelopmentStorage=true"
         JAVA_HOME: $(JAVA_HOME_8_X64)
       displayName: 'Build & Run tests for java 8'
-      condition: eq('${{ parameters.runEndToEndTests }}', true)
+      condition: eq(${{ parameters.runEndToEndTests }}, true)
     

--- a/eng/ci/templates/official/jobs/build-and-test.yml
+++ b/eng/ci/templates/official/jobs/build-and-test.yml
@@ -1,3 +1,9 @@
+parameters:
+  - name: runEndToEndTests
+    type: boolean
+    default: true
+    displayName: "Run end-to-end tests"
+
 jobs:
   - job: "Build_And_Test_Java_Library_Windows"
 
@@ -37,6 +43,7 @@ jobs:
         mvn clean package `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
         Copy-Item "confluent_cloud_cacert.pem" ".\target\azure-functions\azure-functions-java-endtoendtests"
       displayName: 'Package Java for E2E'
+      condition: eq('${{ parameters.runEndToEndTests }}', true)
 
     - task: DotNetCoreCLI@2
       retryCountOnTaskFailure: 3
@@ -66,4 +73,5 @@ jobs:
         ApplicationInsightAPPID: $(ApplicationInsightAPPID)
         ApplicationInsightAgentVersion: $(ApplicationInsightAgentVersion)
       displayName: 'Build & Run tests for java 8'
+      condition: eq('${{ parameters.runEndToEndTests }}', true)
     

--- a/eng/ci/templates/official/jobs/build-and-test.yml
+++ b/eng/ci/templates/official/jobs/build-and-test.yml
@@ -34,13 +34,6 @@ jobs:
     - pwsh: '& .\build.ps1'
       displayName: 'Build project with java core library'
 
-    - task: JavaToolInstaller@1
-      inputs:
-        versionSpec: '8'
-        jdkArchitectureOption: 'x64'
-        jdkSourceOption: 'PreInstalled'
-      condition: eq(${{ parameters.runEndToEndTests }}, true)
-
     - pwsh: |
         $currDir =  Get-Location
         $Env:Path = $Env:Path+";$currDir\Azure.Functions.Cli"

--- a/eng/ci/templates/official/jobs/build-and-test.yml
+++ b/eng/ci/templates/official/jobs/build-and-test.yml
@@ -21,8 +21,16 @@ jobs:
         checkLatest: true
       displayName: 'Install NuGet Tool'
 
+    - task: JavaToolInstaller@1
+      inputs:
+        versionSpec: '8'
+        jdkArchitectureOption: 'x64'
+        jdkSourceOption: 'PreInstalled'
+
     - pwsh: |
         Write-Host "Java_HOME: $JAVA_HOME"
+        Write-Host "Java_HOME: $JAVA_HOME_8_X64"
+        java --version
         Get-Command mvn
       displayName: 'Check Maven is installed'
 
@@ -44,34 +52,20 @@ jobs:
         Copy-Item "confluent_cloud_cacert.pem" ".\target\azure-functions\azure-functions-java-endtoendtests"
       displayName: 'Package Java for E2E'
       condition: eq('${{ parameters.runEndToEndTests }}', true)
-
+    - bash: |
+        docker compose -f azure-functions-java-worker/emulatedtests/utils/docker-compose.yml pull
+        docker compose -f azure-functions-java-worker/emulatedtests/utils/docker-compose.yml up -d
+      displayName: 'Install Azurite and Start Emulators'
+      condition: eq('${{ parameters.runEndToEndTests }}', true)
     - task: DotNetCoreCLI@2
       retryCountOnTaskFailure: 3
       inputs:
         command: 'test'
         projects: |
-          azure-functions-java-worker\endtoendtests\Azure.Functions.Java.Tests.E2E\Azure.Functions.Java.Tests.E2E\Azure.Functions.Java.Tests.E2E.csproj
+          azure-functions-java-worker/emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E.csproj
       env:
-        AzureWebJobsStorage: $(AzureWebJobsStorage)
-        AzureWebJobsCosmosDBConnectionString: $(AzureWebJobsCosmosDBConnectionString)
-        AzureWebJobsSqlConnectionString: $(AzureWebJobsSqlConnectionString)
-        AzureWebJobsServiceBus: $(AzureWebJobsServiceBus)
-        AzureWebJobsEventHubReceiver: $(AzureWebJobsEventHubReceiver)
-        AzureWebJobsEventHubSender_2: $(AzureWebJobsEventHubSender_2)
-        AzureWebJobsEventHubSender: $(AzureWebJobsEventHubSender)
-        AzureWebJobsEventHubPath: $(AzureWebJobsEventHubPath)
-        SBTopicName: $(SBTopicName)
-        SBTopicSubName: $(SBTopicSubName)
-        CosmosDBDatabaseName: $(CosmosDBDatabaseName)
-        SBQueueName: $(SBQueueName)
-        BrokerList": $(BrokerList)
-        ConfluentCloudUsername: $(ConfluentCloudUsername)
-        ConfluentCloudPassword: $(ConfluentCloudPassword)
-        AzureWebJobsEventGridOutputBindingTopicUriString: $(AzureWebJobsEventGridOutputBindingTopicUriString)
-        AzureWebJobsEventGridOutputBindingTopicKeyString: $(AzureWebJobsEventGridOutputBindingTopicKeyString)
-        ApplicationInsightAPIKey: $(ApplicationInsightAPIKey)
-        ApplicationInsightAPPID: $(ApplicationInsightAPPID)
-        ApplicationInsightAgentVersion: $(ApplicationInsightAgentVersion)
+        AzureWebJobsStorage: "UseDevelopmentStorage=true"
+        JAVA_HOME: $(JAVA_HOME_8_X64)
       displayName: 'Build & Run tests for java 8'
       condition: eq('${{ parameters.runEndToEndTests }}', true)
     

--- a/eng/ci/templates/official/jobs/build-and-test.yml
+++ b/eng/ci/templates/official/jobs/build-and-test.yml
@@ -53,9 +53,10 @@ jobs:
       condition: eq(${{ parameters.runEndToEndTests }}, true)
 
     - bash: |
-        docker compose -f azure-functions-java-worker/emulatedtests/utils/docker-compose.yml pull
-        docker compose -f azure-functions-java-worker/emulatedtests/utils/docker-compose.yml up -d
-      displayName: 'Install Azurite and Start Emulators'
+        npm install -g azurite
+        mkdir azurite
+        azurite --silent --location azurite --debug azurite\debug.log &
+      displayName: 'Install and Run Azurite'
       condition: eq(${{ parameters.runEndToEndTests }}, true)
 
     - task: DotNetCoreCLI@2

--- a/eng/ci/templates/official/jobs/build-and-test.yml
+++ b/eng/ci/templates/official/jobs/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
       displayName: 'Install NuGet Tool'
 
     - pwsh: |
-        Write-Host "Java_HOME: $JAVA_HOME"
+        Write-Host "Java_HOME: $env:JAVA_HOME"
         Get-Command mvn
       displayName: 'Check Maven is installed'
 
@@ -46,9 +46,9 @@ jobs:
         $Env:Path = $Env:Path+";$currDir\Azure.Functions.Cli"
         ls $currDir\Azure.Functions.Cli
         func --version
-        cd ./azure-functions-java-worker/endtoendtests
+        cd ./azure-functions-java-worker/emulatedtests
         mvn clean package `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
-        Copy-Item "confluent_cloud_cacert.pem" ".\target\azure-functions\azure-functions-java-endtoendtests"
+        Copy-Item "confluent_cloud_cacert.pem" ".\target\azure-functions\azure-functions-java-emulatedtests"
       displayName: 'Package Java for E2E'
       condition: eq(${{ parameters.runEndToEndTests }}, true)
 

--- a/eng/ci/templates/official/jobs/build-and-test.yml
+++ b/eng/ci/templates/official/jobs/build-and-test.yml
@@ -21,16 +21,8 @@ jobs:
         checkLatest: true
       displayName: 'Install NuGet Tool'
 
-    - task: JavaToolInstaller@1
-      inputs:
-        versionSpec: '8'
-        jdkArchitectureOption: 'x64'
-        jdkSourceOption: 'PreInstalled'
-
     - pwsh: |
         Write-Host "Java_HOME: $JAVA_HOME"
-        Write-Host "Java_HOME: $JAVA_HOME_8_X64"
-        java --version
         Get-Command mvn
       displayName: 'Check Maven is installed'
 
@@ -42,6 +34,13 @@ jobs:
     - pwsh: '& .\build.ps1'
       displayName: 'Build project with java core library'
 
+    - task: JavaToolInstaller@1
+      inputs:
+        versionSpec: '8'
+        jdkArchitectureOption: 'x64'
+        jdkSourceOption: 'PreInstalled'
+      condition: eq('${{ parameters.runEndToEndTests }}', true)
+
     - pwsh: |
         $currDir =  Get-Location
         $Env:Path = $Env:Path+";$currDir\Azure.Functions.Cli"
@@ -52,11 +51,13 @@ jobs:
         Copy-Item "confluent_cloud_cacert.pem" ".\target\azure-functions\azure-functions-java-endtoendtests"
       displayName: 'Package Java for E2E'
       condition: eq('${{ parameters.runEndToEndTests }}', true)
+
     - bash: |
         docker compose -f azure-functions-java-worker/emulatedtests/utils/docker-compose.yml pull
         docker compose -f azure-functions-java-worker/emulatedtests/utils/docker-compose.yml up -d
       displayName: 'Install Azurite and Start Emulators'
       condition: eq('${{ parameters.runEndToEndTests }}', true)
+
     - task: DotNetCoreCLI@2
       retryCountOnTaskFailure: 3
       inputs:


### PR DESCRIPTION
- add exclude paths for codeql
- prevent end-to-end tests from running on scheduled codeql runs

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes are added to the `CHANGELOG.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information