### PR TITLE
Updating core types for kafka extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## azure-functions-java-spi_1.0.0
 
 ### New
-* to be update
+* Added two new types for Kafka Extension - OAuthBearerMethod and KafkaMessageKeyType.
 
 ### Updates
-* to be update
+* Updated the BrokerProtocol type for Kafka Extension.
 
 ### Breaking changes
 * to be update

--- a/azure-functions-java-core-library/src/main/java/com/microsoft/azure/functions/KafkaMessageKeyType.java
+++ b/azure-functions-java-core-library/src/main/java/com/microsoft/azure/functions/KafkaMessageKeyType.java
@@ -5,15 +5,15 @@
  */
 package com.microsoft.azure.functions;
 
-public enum BrokerProtocol {
-    NOTSET(-1),
-    PLAINTEXT(0),
-    SSL(1),
-    SASLPLAINTEXT(2),
-    SASLSSL(3);
+public enum KafkaMessageKeyType {
+    Int(0),
+    Long(1),
+    String(2),
+    Binary(3);
 
     private int value;
-    BrokerProtocol(final int value) {
+
+    KafkaMessageKeyType(final int value) {
         this.value = value;
     }
 

--- a/azure-functions-java-core-library/src/main/java/com/microsoft/azure/functions/OAuthBearerMethod.java
+++ b/azure-functions-java-core-library/src/main/java/com/microsoft/azure/functions/OAuthBearerMethod.java
@@ -5,15 +5,12 @@
  */
 package com.microsoft.azure.functions;
 
-public enum BrokerProtocol {
-    NOTSET(-1),
-    PLAINTEXT(0),
-    SSL(1),
-    SASLPLAINTEXT(2),
-    SASLSSL(3);
+public enum OAuthBearerMethod {
+    Default(0),
+    Oidc(1);
 
     private int value;
-    BrokerProtocol(final int value) {
+    OAuthBearerMethod(final int value) {
         this.value = value;
     }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

With the release of Kafka Extension 4.1.0 following core types need to be added for the Kafka Extension - 
1. OAuthBearerMethod
2. KafkaMessageKeyType

Updated the BrokerProtocol to a include a public getter as a good to have.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes are added to the `CHANGELOG.md`
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information