### PR TITLE
Use NPM to download Functions core tools for tests

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -81,24 +81,28 @@ $skipCliDownload = $args[0]
 Write-Host "skipCliDownload" $skipCliDownload
 if(!$skipCliDownload)
 {
-Write-Host "Deleting Functions Core Tools if exists...."
-Remove-Item -Force ./Azure.Functions.Cli.zip -ErrorAction Ignore
-Remove-Item -Recurse -Force ./Azure.Functions.Cli -ErrorAction Ignore
+$FUNC_RUNTIME_VERSION = 'latest'
 
-Write-Host "Downloading Functions Core Tools...."
-Invoke-RestMethod -Uri "https://functionsclibuilds.blob.core.windows.net/builds/$FUNC_RUNTIME_VERSION/latest/version.txt" -OutFile version.txt
-Write-Host "Using Functions Core Tools version: $(Get-Content -Raw version.txt)"
-Remove-Item version.txt
+Write-Host "Installing Core Tools globlally using npm, version: $FUNC_RUNTIME_VERSION ..."
 
-$url = "https://functionsclibuilds.blob.core.windows.net/builds/$FUNC_RUNTIME_VERSION/latest/Azure.Functions.Cli.$os-$arch.zip"
-$output = "$currDir\Azure.Functions.Cli.zip"
-$wc = New-Object System.Net.WebClient
-$wc.DownloadFile($url, $output)
+$FUNC_CLI_DIRECTORY = Join-Path $currDir 'Azure.Functions.Cli'
 
-Write-Host "Extracting Functions Core Tools...."
-Expand-Archive ".\Azure.Functions.Cli.zip" -DestinationPath ".\Azure.Functions.Cli"
+# 1. Clean previous install
+Remove-Item -Recurse -Force $FUNC_CLI_DIRECTORY -ErrorAction Ignore
+New-Item -ItemType Directory -Path $FUNC_CLI_DIRECTORY -ErrorAction Ignore
+
+# 2. Locate the global prefix and module root that npm just used
+$globalNode   = (npm root   -g | Out-String).Trim()         # e.g. /usr/local/lib/node_modules
+$moduleRoot   = Join-Path $globalNode 'azure-functions-core-tools'
+
+# 3. npm install → temp folder
+npm install -g azure-functions-core-tools@$FUNC_RUNTIME_VERSION --unsafe-perm true --foreground-scripts --loglevel verbose
+
+# 4. Copy CLI payload into the layout required tests
+Copy-Item "$moduleRoot\bin\*" $FUNC_CLI_DIRECTORY -Recurse -Force
 }
 $Env:Path = $Env:Path+";$currDir\Azure.Functions.Cli"
+func --version
 
 # Clone and build azure-functions-java-worker
 git clone https://github.com/azure/azure-functions-java-worker -b dev


### PR DESCRIPTION
This pull request updates the installation process for Azure Functions Core Tools in the `build.ps1` script. Instead of downloading and extracting a zip file manually, the script now installs the tools globally using npm and then copies the necessary files for local use. This streamlines the setup process and ensures consistency with npm-managed installations.

**Core Tools Installation Process Update:**

* Replaced manual download and extraction of Azure Functions Core Tools with a global npm installation (`azure-functions-core-tools@latest`), followed by copying the CLI payload to the required directory (`Azure.Functions.Cli`).
* Added steps to clean up previous installations and create the target directory before copying the new files.
* Updated the script to use the installed CLI version and output its version with `func --version`.