### PR TITLE
Fix multi-content serialization missing polymorphic type discriminator (azure-functions-java-mcp 1.0.1)

### DIFF
--- a/azure-functions-java-mcp/pom.xml
+++ b/azure-functions-java-mcp/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.microsoft.azure.functions</groupId>
     <artifactId>azure-functions-java-mcp</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <name>Microsoft Azure Functions Java MCP Support</name>

--- a/azure-functions-java-mcp/src/main/java/com/microsoft/azure/functions/mcp/McpToolResult.java
+++ b/azure-functions-java-mcp/src/main/java/com/microsoft/azure/functions/mcp/McpToolResult.java
@@ -146,10 +146,29 @@ public class McpToolResult {
 
     /**
      * Serializes a list of Content blocks using the MCP SDK's JSON mapper.
+     *
+     * <p>Uses an explicit {@code List<Content>} collection type so that Jackson emits the
+     * polymorphic {@code "type"} discriminator on each element (e.g. {@code "type":"text"},
+     * {@code "type":"image"}). Without this, Jackson sees each list element via its concrete
+     * runtime type and skips the {@code @JsonTypeInfo} property declared on the {@code Content}
+     * interface, producing JSON like {@code [{"text":"hello"},{"data":"...","mimeType":"..."}]}
+     * which fails polymorphic deserialization on the host side.</p>
      */
     private static String serializeContentList(List<? extends Content> contentBlocks) {
         try {
-            return io.modelcontextprotocol.json.McpJsonDefaults.getMapper().writeValueAsString(contentBlocks);
+            io.modelcontextprotocol.json.McpJsonMapper sdkMapper =
+                    io.modelcontextprotocol.json.McpJsonDefaults.getMapper();
+            // The MCP SDK ships a Jackson-backed mapper by default; reach the underlying
+            // ObjectMapper so we can declare the parameterized element type explicitly.
+            if (sdkMapper instanceof io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper) {
+                com.fasterxml.jackson.databind.ObjectMapper mapper =
+                        ((io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper) sdkMapper).getObjectMapper();
+                return mapper.writerFor(
+                        mapper.getTypeFactory().constructCollectionType(List.class, Content.class)
+                ).writeValueAsString(contentBlocks);
+            }
+            // Fallback for non-Jackson SDK mappers — content may lack type discriminator.
+            return sdkMapper.writeValueAsString(contentBlocks);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to serialize MCP content list", e);
         }

--- a/azure-functions-java-mcp/src/test/java/com/microsoft/azure/functions/mcp/McpToolResultMiddlewareTest.java
+++ b/azure-functions-java-mcp/src/test/java/com/microsoft/azure/functions/mcp/McpToolResultMiddlewareTest.java
@@ -178,6 +178,42 @@ class McpToolResultMiddlewareTest {
     }
 
     // ========================================================================
+    // Regression: list elements must include the polymorphic "type" discriminator
+    // so the host extension can deserialize as IEnumerable<ContentBlock>.
+    // ========================================================================
+
+    @Test
+    void mcpToolResult_fromContentList_each_element_has_type_discriminator() {
+        McpToolResult result = McpToolResult.fromContentList(Arrays.asList(
+                new TextContent("hello"),
+                new ImageContent(null, "base64data", "image/png")
+        ));
+
+        // Inner content is a JSON array. Each element must carry "type".
+        com.google.gson.JsonArray array = com.google.gson.JsonParser
+                .parseString(result.getContent())
+                .getAsJsonArray();
+        assertEquals(2, array.size());
+
+        JsonObject first = array.get(0).getAsJsonObject();
+        assertTrue(first.has("type"), "first element missing \"type\" discriminator: " + first);
+        assertEquals("text", first.get("type").getAsString());
+
+        JsonObject second = array.get(1).getAsJsonObject();
+        assertTrue(second.has("type"), "second element missing \"type\" discriminator: " + second);
+        assertEquals("image", second.get("type").getAsString());
+    }
+
+    @Test
+    void mcpToolResult_fromContent_single_image_has_type_discriminator() {
+        McpToolResult result = McpToolResult.fromContent(new ImageContent(null, "x", "image/png"));
+
+        JsonObject obj = com.google.gson.JsonParser.parseString(result.getContent()).getAsJsonObject();
+        assertTrue(obj.has("type"), "single content missing \"type\" discriminator: " + obj);
+        assertEquals("image", obj.get("type").getAsString());
+    }
+
+    // ========================================================================
     // Helper types
     // ========================================================================
 


### PR DESCRIPTION
## Summary

Fix `getMultiContent`-style MCP tools (functions returning `List<Content>`) failing with `An error occurred invoking '<tool>'` and `Unknown content type: ''` on the host side. Restores end-to-end multi-content support for the Java MCP middleware.

## Problem

`McpToolResult.serializeContentList` was calling `mapper.writeValueAsString(list)` on a raw `List<? extends Content>`. Jackson inspects each element's concrete runtime type (`TextContent`, `ImageContent`, etc.) and **skips the `@JsonTypeInfo` declared on the `Content` interface**, producing JSON like:

```json
[{"text":"hello"},{"data":"...","mimeType":"image/png"}]
```

— with no `"type"` discriminator on the elements.

The host extension's polymorphic `ContentBlock` deserializer ([`ToolReturnValueBinder.DeserializeToContentBlockCollection`](https://github.com/Azure/azure-functions-mcp-extension/blob/main/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/ToolReturnValueBinder.cs)) fails on this with:

```
Failed to deserialize content for type 'multi_content_result'.
ModelContextProtocol.Core: Unknown content type: ''.
```

The chat client surfaces this as `"An error occurred invoking '<tool>'."`.

## Fix

Declare the element type explicitly when serializing the list, so Jackson emits the polymorphic `"type"` field on each element:

```java
mapper.writerFor(
    mapper.getTypeFactory().constructCollectionType(List.class, Content.class)
).writeValueAsString(contentBlocks);
```

Falls back to the previous `sdkMapper.writeValueAsString(list)` path if the SDK ships a non-Jackson `McpJsonMapper`.

After the fix the inner JSON is:

```json
[{"type":"text","text":"hello"},{"type":"image","data":"...","mimeType":"image/png"}]
```

which the host deserializes correctly.

## Why it slipped through

- The existing `fromContentList` unit test asserted only that the envelope `type` was `multi_content_result` and that `getContent()` was non-null — it never parsed the inner JSON to verify the element shape.
- The single-content path (`fromContent(Content)`) already worked because the declared parameter type *is* the `Content` interface, so Jackson's polymorphism kicked in. Reviewers reasonably assumed the list path behaved the same way.
- The failure manifests only across the worker → host language boundary; pure-Java tests don't exercise it.
- Failure mode in chat is "tool hangs" or generic "An error occurred", with the root cause buried in the host log.

## Changes

- **`azure-functions-java-mcp/src/main/java/.../McpToolResult.java`** — `serializeContentList` now uses `writerFor(List<Content>)` to preserve the polymorphic discriminator.
- **`azure-functions-java-mcp/src/test/java/.../McpToolResultMiddlewareTest.java`** — adds two regression tests:
  - `mcpToolResult_fromContentList_each_element_has_type_discriminator` — asserts every element in the inner JSON array carries `"type":"<text|image|...>"`.
  - `mcpToolResult_fromContent_single_image_has_type_discriminator` — guardrail for the single-content path so it can't silently regress.
- **`azure-functions-java-mcp/pom.xml`** — version bump `1.0.0` → `1.0.1`.

## Test plan

- `mvn -B clean test` in `azure-functions-java-mcp`: **16 / 16 pass** (was 14; added 2 regression tests).
- End-to-end verified against a sample Functions Java MCP app + host extension:
  - Without the fix (1.0.0): `getMultiContent` returns `An error occurred invoking 'getMultiContent'.`; host log shows `Failed to deserialize content for type 'multi_content_result'. ModelContextProtocol.Core: Unknown content type: ''.`
  - With the fix (1.0.1): `getMultiContent` returns the text + image blocks correctly; round-trip latency ~100 ms.
- Single-content tools (`renderImage` returning `ImageContent`) and `@McpContent`-annotated POJOs continue to work — no regression.

## Compatibility

- No API surface change.
- No behaviour change for the single-content path or for `@McpContent` POJOs.
- Behaviour change is strictly corrective for `List<Content>` returns.
